### PR TITLE
NanoAOD BPH Kll refitting

### DIFF
--- a/PhysicsTools/NanoAOD/python/BToKee_cff.py
+++ b/PhysicsTools/NanoAOD/python/BToKee_cff.py
@@ -11,7 +11,7 @@ BToKee=cms.EDProducer("BToKeeProducer",
                       KaonMinPt=cms.double(1.),
                       KaonMaxEta=cms.double(2.4),
                       KaonMinDCASig=cms.double(3.3),
-                      DiElectronChargeCheck=cms.bool(True),
+                      DiElectronChargeCheck=cms.bool(False),
                       RunDiElectronRefitting=cms.bool(True)
                       )
 

--- a/PhysicsTools/NanoAOD/python/BToKee_cff.py
+++ b/PhysicsTools/NanoAOD/python/BToKee_cff.py
@@ -11,7 +11,8 @@ BToKee=cms.EDProducer("BToKeeProducer",
                       KaonMinPt=cms.double(1.),
                       KaonMaxEta=cms.double(2.4),
                       KaonMinDCASig=cms.double(3.3),
-                      DiElectronChargeCheck=cms.bool(True)
+                      DiElectronChargeCheck=cms.bool(True),
+                      RunDiElectronRefitting=cms.bool(True)
                       )
 
 BToKeeTable=cms.EDProducer("SimpleCompositeCandidateFlatTableProducer", 

--- a/PhysicsTools/NanoAOD/python/BToKmumu_cff.py
+++ b/PhysicsTools/NanoAOD/python/BToKmumu_cff.py
@@ -12,7 +12,8 @@ BToKmumu=cms.EDProducer("BToKmumuProducer",
                         KaonMinPt=cms.double(1.),
                         KaonMaxEta=cms.double(2.4),
                         KaonMinDCASig=cms.double(3.3),
-                        DiMuonChargeCheck=cms.bool(True)
+                        DiMuonChargeCheck=cms.bool(True),
+                        RunDiMuonRefitting=cms.bool(True)
                         )
 
 BToKmumuTable=cms.EDProducer("SimpleCompositeCandidateFlatTableProducer", 

--- a/PhysicsTools/NanoAOD/python/BToKmumu_cff.py
+++ b/PhysicsTools/NanoAOD/python/BToKmumu_cff.py
@@ -12,7 +12,7 @@ BToKmumu=cms.EDProducer("BToKmumuProducer",
                         KaonMinPt=cms.double(1.),
                         KaonMaxEta=cms.double(2.4),
                         KaonMinDCASig=cms.double(3.3),
-                        DiMuonChargeCheck=cms.bool(True),
+                        DiMuonChargeCheck=cms.bool(False),
                         RunDiMuonRefitting=cms.bool(True)
                         )
 


### PR DESCRIPTION
- Adding optional flag to run dilepton refitting + store associated variables in BToKll producers
Default behaviour unchanged for now (dilepton refitting run) as no triplet selection based on the dilepton refitting variable is applied in the config
Only possible difference can come from failing fits

- Relaxing dilepton charge check, as charge can flip in refitting